### PR TITLE
Error out if a provided map name is too long

### DIFF
--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -1993,6 +1993,9 @@ static const char *_add_tile_config(cmd_parms *cmd, void *mconfig,
 	if (strlen(name) == 0) {
 		return "ConfigName value must not be null";
 	}
+	if (strlen(name) > (XMLCONFIG_MAX - 1)) {
+		return "ConfigName value is too long";
+	}
 
 	if (hostnames == NULL) {
 		hostnames = malloc(sizeof(char *));


### PR DESCRIPTION
Otherwise, the name is silently truncated later. It's better to alert the sysadmin earlier

(test for GH actions)